### PR TITLE
Added user approved event to webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Discourse User Created Webhook
+# Discourse User Created/Approved Webhook
 
-This should add a user to a mailchimp list when their user is created in Discourse.
+This should add a user to a mailchimp list when their user is created or approved in Discourse.
 
 The client that I developed this for no longer uses Discourse, so I don't have means (or much desire) to test it.
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -5,3 +5,6 @@ en:
         user_created_event:
           name: "User Created Event"
           details: "When there is a new user created."
+        user_approved_event:
+          name: "User Approved Event"
+          details: "When a new user has been approved."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,6 +1,6 @@
 en:
   site_settings:
-    discourse_mailchimp_webhook_enabled: "Enable Discourse user created webhook plugin"
+    discourse_mailchimp_webhook_enabled: "Enable Discourse user created/approved webhook plugin"
     mailchimp_list_id: "List ID (probably 10 digit hex)"
     mailchimp_api_key: "Mailchimp API key"
     mailchimp_dc: "Mailchimp Data Center--If the last part of your Mailchimp API key is us6, then this is us6"

--- a/db/fixtures/002_user_web_hook.rb
+++ b/db/fixtures/002_user_web_hook.rb
@@ -1,0 +1,4 @@
+WebHookEventType.seed do |b|
+  b.id = 106
+  b.name = "user_approved"
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -21,12 +21,16 @@ after_initialize do
   end
 
   Plugin::Filter.register(:after_build_web_hook_body) do |context, body|
-    body['user_created'].each do |param, value|
-      body[param] = value
+    if body['user_created']
+      body['user_created'].each do |param, value|
+        body[param] = value
+      end
     end
 
-    body['user_approved'].each do |param, value|
-      body[param] = value
+    if body['user_approved']
+      body['user_approved'].each do |param, value|
+        body[param] = value
+      end
     end
     
     body

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,6 +1,6 @@
 # name: discourse-mailchimp-webhook
-# version: 0.1
-# authors: Jay Pfaffman (jay@literatecomputing.com) and Angus McLeod
+# version: 0.2
+# authors: Jay Pfaffman (jay@literatecomputing.com), Angus McLeod and HappyPorch
 
 PLUGIN_NAME = 'discourse_mailchimp_webhook'.freeze
 
@@ -16,8 +16,16 @@ after_initialize do
     WebHook.enqueue_object_hooks(:user_created, user, 'user_created', MailchimpSerializer)
   end
 
+  DiscourseEvent.on(:user_approved) do |user|
+    WebHook.enqueue_object_hooks(:user_approved, user, 'user_approved', MailchimpSerializer)
+  end
+
   Plugin::Filter.register(:after_build_web_hook_body) do |context, body|
     body['user_created'].each do |param, value|
+      body[param] = value
+    end
+
+    body['user_approved'].each do |param, value|
       body[param] = value
     end
     


### PR DESCRIPTION
For a Discourse instance where we were using your plugin, we had the additional requirement that a user should only be added to the mailing list once approved by an admin.

Therefore this PR contains an additional webhook event that gets triggered when a new user has been approved and then calls the Mailchimp serializer as per your original plugin.
This then allows the admin in Discourse to select either the User Created Event or User Approved Event when adding a new webhook.